### PR TITLE
renamed test-file and -class

### DIFF
--- a/include/libKitsuneCommon/testing/unit_test.h
+++ b/include/libKitsuneCommon/testing/unit_test.h
@@ -1,5 +1,5 @@
 /**
- *  @file    test.h
+ *  @file    unit_test.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -23,7 +23,7 @@ namespace Kitsune
 namespace Common
 {
 
-class Test
+class UnitTest
 {
 #define UNITTEST(IS_VAL, SHOULD_VAL) if(IS_VAL != SHOULD_VAL) \
 {  \
@@ -57,8 +57,8 @@ class Test
     }
 
 public:
-    Test(const std::string testName);
-    ~Test();
+    UnitTest(const std::string testName);
+    ~UnitTest();
 
 protected:
     uint32_t m_successfulTests = 0;

--- a/src/src.pro
+++ b/src/src.pro
@@ -9,12 +9,12 @@ INCLUDEPATH += $$PWD \
             ../include/libKitsuneCommon
 
 SOURCES += \
-    testing/test.cpp \
     threading/thread.cpp \
     statemachine/statemachine.cpp \
     buffering/data_buffer_methods.cpp \
     common_items/data_items.cpp \
-    common_items/table_item.cpp
+    common_items/table_item.cpp \
+    testing/unit_test.cpp
 
 HEADERS += \
     ../include/libKitsuneCommon/buffering/data_buffer.h \
@@ -23,7 +23,7 @@ HEADERS += \
     ../include/libKitsuneCommon/common_methods/vector_methods.h \
     ../include/libKitsuneCommon/common_items/data_items.h \
     ../include/libKitsuneCommon/statemachine/statemachine.h \
-    ../include/libKitsuneCommon/testing/test.h \
     ../include/libKitsuneCommon/threading/thread.h \
     statemachine/state.h \
-    ../include/libKitsuneCommon/common_items/table_item.h
+    ../include/libKitsuneCommon/common_items/table_item.h \
+    ../include/libKitsuneCommon/testing/unit_test.h

--- a/src/testing/unit_test.cpp
+++ b/src/testing/unit_test.cpp
@@ -1,5 +1,5 @@
 /**
- *  @file    test.cpp
+ *  @file    unit_test.cpp
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -12,20 +12,20 @@
  *          shows the file-name, linenumer and method-name of the failed test.
  */
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
 namespace Common
 {
 
-Test::Test(const std::string testName)
+UnitTest::UnitTest(const std::string testName)
 {
     std::cout << "------------------------------" << std::endl;
     std::cout << "start " << testName << std::endl << std::endl;
 }
 
-Test::~Test()
+UnitTest::~UnitTest()
 {
     std::cout << "tests succeeded: " << m_successfulTests <<std::endl;
     std::cout << "tests failed: " << m_failedTests << std::endl;

--- a/tests/libKitsuneCommon/buffering/data_buffer_methods_test.cpp
+++ b/tests/libKitsuneCommon/buffering/data_buffer_methods_test.cpp
@@ -24,7 +24,7 @@ struct TestStruct
 } __attribute__((packed));
 
 DataBufferMethods_Test::DataBufferMethods_Test()
-    : Kitsune::Common::Test("DataBufferMethods_Test")
+    : Kitsune::Common::UnitTest("DataBufferMethods_Test")
 {
     addDataToBuffer_test();
     allocateBlocks_test();

--- a/tests/libKitsuneCommon/buffering/data_buffer_methods_test.h
+++ b/tests/libKitsuneCommon/buffering/data_buffer_methods_test.h
@@ -9,7 +9,7 @@
 #ifndef DATA_BUFFER_METHODS_TEST_H
 #define DATA_BUFFER_METHODS_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 
 class DataBufferMethods_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     DataBufferMethods_Test();

--- a/tests/libKitsuneCommon/buffering/data_buffer_test.cpp
+++ b/tests/libKitsuneCommon/buffering/data_buffer_test.cpp
@@ -23,7 +23,7 @@ struct TestStruct
 } __attribute__((packed));
 
 DataBuffer_Test::DataBuffer_Test()
-    : Kitsune::Common::Test("DataBuffer_Test")
+    : Kitsune::Common::UnitTest("DataBuffer_Test")
 {
     structSize_test();
     constructor_test();

--- a/tests/libKitsuneCommon/buffering/data_buffer_test.h
+++ b/tests/libKitsuneCommon/buffering/data_buffer_test.h
@@ -9,7 +9,7 @@
 #ifndef DATA_BUFFER_TEST_H
 #define DATA_BUFFER_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 
 class DataBuffer_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     DataBuffer_Test();

--- a/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
@@ -15,7 +15,7 @@ namespace Common
 {
 
 DataItems_DataArray_Test::DataItems_DataArray_Test()
-    : Kitsune::Common::Test("DataItems_DataArray_Test")
+    : Kitsune::Common::UnitTest("DataItems_DataArray_Test")
 {
     operator_test();
     get_test();

--- a/tests/libKitsuneCommon/common_items/data_items_DataArray_test.h
+++ b/tests/libKitsuneCommon/common_items/data_items_DataArray_test.h
@@ -9,7 +9,7 @@
 #ifndef DATAITEMS_DATAARRAY_TEST_H
 #define DATAITEMS_DATAARRAY_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -18,7 +18,7 @@ namespace Common
 class DataArray;
 
 class DataItems_DataArray_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     DataItems_DataArray_Test();

--- a/tests/libKitsuneCommon/common_items/data_items_DataObject_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataObject_test.cpp
@@ -15,7 +15,7 @@ namespace Common
 {
 
 DataItems_DataObject_Test::DataItems_DataObject_Test()
-    : Kitsune::Common::Test("DataItems_DataObject_Test")
+    : Kitsune::Common::UnitTest("DataItems_DataObject_Test")
 {
     operator_test();
     get_test();

--- a/tests/libKitsuneCommon/common_items/data_items_DataObject_test.h
+++ b/tests/libKitsuneCommon/common_items/data_items_DataObject_test.h
@@ -9,7 +9,7 @@
 #ifndef DATAITEMS_DATAOBJECT_TEST_H
 #define DATAITEMS_DATAOBJECT_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -18,7 +18,7 @@ namespace Common
 class DataObject;
 
 class DataItems_DataObject_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     DataItems_DataObject_Test();

--- a/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
@@ -15,7 +15,7 @@ namespace Common
 {
 
 DataItems_DataValue_Test::DataItems_DataValue_Test()
-    : Kitsune::Common::Test("DataItems_DataValue_Test")
+    : Kitsune::Common::UnitTest("DataItems_DataValue_Test")
 {
     operator_test();
     get_test();

--- a/tests/libKitsuneCommon/common_items/data_items_DataValue_test.h
+++ b/tests/libKitsuneCommon/common_items/data_items_DataValue_test.h
@@ -9,7 +9,7 @@
 #ifndef DATAITEMS_DATAVALUE_TEST_H
 #define DATAITEMS_DATAVALUE_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 class DataValue;
 
-class DataItems_DataValue_Test : public Kitsune::Common::Test
+class DataItems_DataValue_Test : public Kitsune::Common::UnitTest
 {
 public:
     DataItems_DataValue_Test();

--- a/tests/libKitsuneCommon/common_items/table_item_test.cpp
+++ b/tests/libKitsuneCommon/common_items/table_item_test.cpp
@@ -14,7 +14,7 @@ namespace Common
 {
 
 TableItem_test::TableItem_test()
-    : Kitsune::Common::Test("TableItem_test")
+    : Kitsune::Common::UnitTest("TableItem_test")
 {
     copy_contructor_test();
     assignment_operator_test();

--- a/tests/libKitsuneCommon/common_items/table_item_test.h
+++ b/tests/libKitsuneCommon/common_items/table_item_test.h
@@ -9,7 +9,7 @@
 #ifndef TABLE_ITEM_TEST_H
 #define TABLE_ITEM_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 #include <common_items/table_item.h>
 
 namespace Kitsune
@@ -18,7 +18,7 @@ namespace Common
 {
 
 class TableItem_test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     TableItem_test();

--- a/tests/libKitsuneCommon/common_methods/string_methods_test.cpp
+++ b/tests/libKitsuneCommon/common_methods/string_methods_test.cpp
@@ -16,7 +16,7 @@ namespace Common
 {
 
 StringMethods_Test::StringMethods_Test()
-    : Kitsune::Common::Test("StringMethods_Test")
+    : Kitsune::Common::UnitTest("StringMethods_Test")
 {
     splitString_test();
 }

--- a/tests/libKitsuneCommon/common_methods/string_methods_test.h
+++ b/tests/libKitsuneCommon/common_methods/string_methods_test.h
@@ -9,7 +9,7 @@
 #ifndef STRING_METHODS_TEST_H
 #define STRING_METHODS_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 
 class StringMethods_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     StringMethods_Test();

--- a/tests/libKitsuneCommon/common_methods/vector_methods_test.cpp
+++ b/tests/libKitsuneCommon/common_methods/vector_methods_test.cpp
@@ -16,7 +16,7 @@ namespace Common
 {
 
 TextFile_Test::TextFile_Test()
-    : Kitsune::Common::Test("VectorMethods_Test")
+    : Kitsune::Common::UnitTest("VectorMethods_Test")
 {
     removeEmptyStrings_test();
 }

--- a/tests/libKitsuneCommon/common_methods/vector_methods_test.h
+++ b/tests/libKitsuneCommon/common_methods/vector_methods_test.h
@@ -9,7 +9,7 @@
 #ifndef VECTOR_METHODS_TEST_H
 #define VECTOR_METHODS_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 
 class TextFile_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     TextFile_Test();

--- a/tests/libKitsuneCommon/statemachine/state_test.cpp
+++ b/tests/libKitsuneCommon/statemachine/state_test.cpp
@@ -16,7 +16,7 @@ namespace Common
 {
 
 State_Test::State_Test()
-    : Kitsune::Common::Test("State_Test")
+    : Kitsune::Common::UnitTest("State_Test")
 {
     addTransition_test();
     next_test();

--- a/tests/libKitsuneCommon/statemachine/state_test.h
+++ b/tests/libKitsuneCommon/statemachine/state_test.h
@@ -9,7 +9,7 @@
 #ifndef STATE_TEST_H
 #define STATE_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 
 class State_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     State_Test();

--- a/tests/libKitsuneCommon/statemachine/statemachine_test.cpp
+++ b/tests/libKitsuneCommon/statemachine/statemachine_test.cpp
@@ -16,7 +16,7 @@ namespace Common
 {
 
 Statemachine_Test::Statemachine_Test()
-    : Kitsune::Common::Test("Statemachine_Test")
+    : Kitsune::Common::UnitTest("Statemachine_Test")
 {
     createNewState_test();
     addTransition_test();

--- a/tests/libKitsuneCommon/statemachine/statemachine_test.h
+++ b/tests/libKitsuneCommon/statemachine/statemachine_test.h
@@ -9,7 +9,7 @@
 #ifndef STATEMACHINE_TEST_H
 #define STATEMACHINE_TEST_H
 
-#include <testing/test.h>
+#include <testing/unit_test.h>
 
 namespace Kitsune
 {
@@ -17,7 +17,7 @@ namespace Common
 {
 
 class Statemachine_Test
-        : public Kitsune::Common::Test
+        : public Kitsune::Common::UnitTest
 {
 public:
     Statemachine_Test();


### PR DESCRIPTION
As preparation for adding new tests in the future the current test-stuff was renamed
to be more specific.

renamed:

file: test.h -> unit_test.h
file: test.cpp -> unit_test.cpp
class: Test -> UnitTest