### PR TITLE
updates for tagging 0.16.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.16.0] - 2020-11-25
+
+### Added
+- Cleanup-Thread, to delete threads in the backgroud, which are scheduled for deletion
+- missing memory-leak tests
+- some missing comments
+
+### Removed
+- Removed some functions to stop a thread  
+
+
 ## [0.15.2] - 2020-10-18
 
 ###  Fixed

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT       -= qt core gui
 TARGET = KitsunemimiCommon
 TEMPLATE = lib
 CONFIG += c++14
-VERSION = 0.15.2
+VERSION = 0.16.0
 
 INCLUDEPATH += $$PWD \
             ../include


### PR DESCRIPTION
## Description

updates for tagging 0.16.0

## Related Issues

- #121 

## How it was tested?

- ci-pipeline
