### PR TITLE
Possible memory leak when delete thread

### DIFF
--- a/include/libKitsunemimiCommon/threading/thread.h
+++ b/include/libKitsunemimiCommon/threading/thread.h
@@ -46,6 +46,7 @@ public:
     bool bindThreadToCore(const int coreId);
 
     void addEventToQueue(Event* newEvent);
+    void clearEventQueue();
 
 protected:
     bool m_abort = false;

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -40,6 +40,8 @@ Thread::~Thread()
     ThreadHandler::getInstance()->unregisterThread();
     stopThread();
     clearEventQueue();
+
+    delete m_thread;
 }
 
 /**

--- a/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_event.cpp
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_event.cpp
@@ -1,0 +1,22 @@
+/**
+ *  @file      bogus_event.cpp
+ *
+ *  @author    Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright MIT License
+ */
+
+#include "bogus_event.h"
+
+namespace Kitsunemimi
+{
+
+BogusEvent::BogusEvent() {}
+
+bool
+BogusEvent::processEvent()
+{
+    return true;
+}
+
+}

--- a/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_event.h
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_event.h
@@ -1,0 +1,28 @@
+/**
+ *  @file      bogus_event.h
+ *
+ *  @author    Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright MIT License
+ */
+
+#ifndef BOGUS_EVENT_H
+#define BOGUS_EVENT_H
+
+#include <libKitsunemimiCommon/threading/event.h>
+
+namespace Kitsunemimi
+{
+
+class BogusEvent
+        : public Kitsunemimi::Event
+{
+public:
+    BogusEvent();
+
+    bool processEvent();
+};
+
+}
+
+#endif // BOGUS_EVENT_H

--- a/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_thread.cpp
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_thread.cpp
@@ -1,0 +1,23 @@
+/**
+ *  @file      bogus_thread.cpp
+ *
+ *  @author    Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright MIT License
+ */
+
+#include "bogus_thread.h"
+
+namespace Kitsunemimi
+{
+
+BogusThread::BogusThread() {}
+
+void BogusThread::run()
+{
+    while(m_abort == false) {
+        sleepThread(10000);
+    }
+}
+
+}

--- a/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_thread.h
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/threading/bogus_thread.h
@@ -1,0 +1,29 @@
+/**
+ *  @file      bogus_thread.h
+ *
+ *  @author    Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright MIT License
+ */
+
+#ifndef BOGUS_THREAD_H
+#define BOGUS_THREAD_H
+
+#include <libKitsunemimiCommon/threading/thread.h>
+
+namespace Kitsunemimi
+{
+
+class BogusThread
+        : public Kitsunemimi::Thread
+{
+public:
+    BogusThread();
+
+protected:
+    void run();
+};
+
+}
+
+#endif // BOGUS_THREAD_H

--- a/tests/memory_leak_tests/libKitsunemimiCommon/threading/thread_test.cpp
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/threading/thread_test.cpp
@@ -1,0 +1,67 @@
+/**
+ *  @file      thread_test.cpp
+ *
+ *  @author    Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright MIT License
+ */
+
+#include "thread_test.h"
+
+#include <libKitsunemimiCommon/threading/thread.h>
+#include <libKitsunemimiCommon/threading/event.h>
+
+#include "bogus_event.h"
+#include "bogus_thread.h"
+
+namespace Kitsunemimi
+{
+
+Thread_Test::Thread_Test()
+    : Kitsunemimi::MemoryLeakTestHelpter("DataBuffer_Test")
+{
+    // The first created thread initialize a static instance of a central thread-handler to
+    // track all threads. This will not be deleted anytime, so one thread has to be created
+    // outside of the test-case.
+    Kitsunemimi::Thread* testThread = new BogusThread();
+    delete testThread;
+
+    create_delete_test();
+    create_delete_with_events_test();
+}
+
+/**
+ * @brief create_delete_test
+ */
+void
+Thread_Test::create_delete_test()
+{
+    REINIT_TEST();
+
+    Kitsunemimi::Thread* testThread = new BogusThread();
+    testThread->startThread();
+    usleep(100000);
+    delete testThread;
+
+    CHECK_MEMORY();
+}
+
+/**
+ * @brief create_delete_with_events_test
+ */
+void
+Thread_Test::create_delete_with_events_test()
+{
+    REINIT_TEST();
+
+    Kitsunemimi::Thread* testThread = new BogusThread();
+    testThread->startThread();
+    Event* testEvent = new BogusEvent();
+    testThread->addEventToQueue(testEvent);
+    usleep(100000);
+    delete testThread;
+
+    CHECK_MEMORY();
+}
+
+}

--- a/tests/memory_leak_tests/libKitsunemimiCommon/threading/thread_test.h
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/threading/thread_test.h
@@ -1,0 +1,31 @@
+/**
+ *  @file      thread_test.h
+ *
+ *  @author    Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright MIT License
+ */
+
+#ifndef THREAD_TEST_H
+#define THREAD_TEST_H
+
+#include <unistd.h>
+#include <libKitsunemimiCommon/test_helper/memory_leak_test_helper.h>
+
+namespace Kitsunemimi
+{
+
+class Thread_Test
+        : public Kitsunemimi::MemoryLeakTestHelpter
+{
+public:
+    Thread_Test();
+
+private:
+    void create_delete_test();
+    void create_delete_with_events_test();
+};
+
+}
+
+#endif // THREAD_TEST_H

--- a/tests/memory_leak_tests/main.cpp
+++ b/tests/memory_leak_tests/main.cpp
@@ -19,6 +19,8 @@
 #include <libKitsunemimiCommon/common_items/data_items_test.h>
 #include <libKitsunemimiCommon/common_items/table_item_test.h>
 
+#include <libKitsunemimiCommon/threading/thread_test.h>
+
 int main()
 {
     Kitsunemimi::DataBuffer_Test();
@@ -31,4 +33,6 @@ int main()
 
     Kitsunemimi::DataItems_Test();
     Kitsunemimi::TableItem_test();
+
+    Kitsunemimi::Thread_Test();
 }

--- a/tests/memory_leak_tests/memory_leak_tests.pro
+++ b/tests/memory_leak_tests/memory_leak_tests.pro
@@ -16,7 +16,10 @@ HEADERS += \
     libKitsunemimiCommon/buffer/ring_buffer_test.h \
     libKitsunemimiCommon/buffer/stack_buffer_reserve_test.h \
     libKitsunemimiCommon/buffer/stack_buffer_test.h \
-    libKitsunemimiCommon/common_items/data_items_test.h
+    libKitsunemimiCommon/common_items/data_items_test.h \
+    libKitsunemimiCommon/threading/thread_test.h \
+    libKitsunemimiCommon/threading/bogus_event.h \
+    libKitsunemimiCommon/threading/bogus_thread.h
 
 SOURCES += \
     main.cpp \
@@ -27,4 +30,7 @@ SOURCES += \
     libKitsunemimiCommon/buffer/ring_buffer_test.cpp \
     libKitsunemimiCommon/buffer/stack_buffer_reserve_test.cpp \
     libKitsunemimiCommon/buffer/stack_buffer_test.cpp \
-    libKitsunemimiCommon/common_items/data_items_test.cpp
+    libKitsunemimiCommon/common_items/data_items_test.cpp \
+    libKitsunemimiCommon/threading/thread_test.cpp \
+    libKitsunemimiCommon/threading/bogus_event.cpp \
+    libKitsunemimiCommon/threading/bogus_thread.cpp


### PR DESCRIPTION
## Description

fixed memory-leaks in thread-object in case of deletion

## Related Issues

- #125 

## How it was tested?

- ci-pipeline
