### PR TITLE
updates for tagging 0.19.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.19.0] - 2021-09-26
+
+### Added
+- progress-bar for terminal output
+- optional static part at the beginning of item-buffers
+
+### Changed
+- changed minimal block-size of data-buffer from 512 to 8 byte
+
+
 ## [0.18.0] - 2021-03-29
 
 ### Added

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT       -= qt core gui
 TARGET = KitsunemimiCommon
 TEMPLATE = lib
 CONFIG += c++14
-VERSION = 0.18.0
+VERSION = 0.19.0
 
 INCLUDEPATH += $$PWD \
             ../include


### PR DESCRIPTION
## Description

updates for tagging 0.19.0

## Related Issues

- #139 

## How it was tested?

- ci-pipeline
