### PR TITLE
add json-formated output for table-items

### DIFF
--- a/include/libKitsunemimiCommon/common_items/table_item.h
+++ b/include/libKitsunemimiCommon/common_items/table_item.h
@@ -71,6 +71,7 @@ public:
     // output
     const std::string toString(const uint32_t maxColumnWidth = 500,
                                const bool withoutHeader = false);
+    const std::string toJsonString();
 
 private:
     DataArray* m_body = nullptr;

--- a/src/common_items/table_item.cpp
+++ b/src/common_items/table_item.cpp
@@ -447,6 +447,23 @@ TableItem::toString(const uint32_t maxColumnWidth,
 }
 
 /**
+ * @brief converts header and body of the table into one single json-formated string without indent
+ *
+ * @return json-string
+ */
+const std::string
+TableItem::toJsonString()
+{
+    std::string result = "{ header: ";
+    result.append(m_header->toString());
+    result.append(", body: ");
+    result.append(m_body->toString());
+    result.append("}");
+    Kitsunemimi::replaceSubstring(result, "\n", "\\n");
+    return result;
+}
+
+/**
  * @brief output of the content as classic table.
  *
  * @param convertedBody content of the body in converted form

--- a/tests/unit_tests/libKitsunemimiCommon/common_items/table_item_test.cpp
+++ b/tests/unit_tests/libKitsunemimiCommon/common_items/table_item_test.cpp
@@ -318,6 +318,15 @@ TableItem_test::toString_test()
 
     // test with a maximum cell width of 9
     TEST_EQUAL(testItem.toString(9, true), compareWithoutHeader);
+
+    // check json-formated output
+    const std::string compareJson = "{ header: [{\"inner\":\"asdf\",\"outer\":\"ASDF\"},"
+                                    "{\"inner\":\"poipoipoi\",\"outer\":\"poipoipoi\"}], "
+                                    "body: [{\"asdf\":\"this is a test\",\"poipoipoi\":\"k\"},"
+                                    "{\"asdf\":\"asdf\",\"poipoipoi\":\"qwert\"},"
+                                    "{\"asdf\":\"x\\ny\\nz\",\"poipoipoi\":\" \"},"
+                                    "{\"asdf\":\"y\",\"poipoipoi\":\"abcdefghijklmnopqrst\"}]}";
+    TEST_EQUAL(testItem.toJsonString(), compareJson);
 }
 
 /**


### PR DESCRIPTION
## Description

add json-formated output for table-items

## Related Issues

- #167 

## How it was tested?

- new unit-tests for ci
