### PR TITLE
fix writeCompleteFile-function to writhe the correct size

### DIFF
--- a/src/files/binary_file.cpp
+++ b/src/files/binary_file.cpp
@@ -206,17 +206,16 @@ BinaryFile::writeCompleteFile(DataBuffer &buffer)
     }
 
     // resize file to the size of the buffer
-    int64_t sizeDiff = (buffer.numberOfBlocks * buffer.blockSize) - m_totalFileSize;
+    int64_t sizeDiff = buffer.usedBufferSize - m_totalFileSize;
     if(sizeDiff > 0)
     {
         // round diff up to full block-size
-        if(sizeDiff % buffer.blockSize != 0) {
-            sizeDiff += buffer.blockSize - (sizeDiff % buffer.blockSize);
+        if(sizeDiff % m_blockSize != 0) {
+            sizeDiff += m_blockSize - (sizeDiff % m_blockSize);
         }
 
         // allocate additional memory
-        const bool success = allocateStorage(sizeDiff);
-        if(success == false) {
+        if(allocateStorage(sizeDiff) == false) {
             return false;
         }
     }

--- a/tests/unit_tests/libKitsunemimiCommon/files/binary_file_with_directIO_test.cpp
+++ b/tests/unit_tests/libKitsunemimiCommon/files/binary_file_with_directIO_test.cpp
@@ -219,6 +219,7 @@ BinaryFile_withDirectIO_Test::writeCompleteFile_test()
     buffer.usedBufferSize = 2 * buffer.blockSize;
 
     TEST_EQUAL(binaryFile.writeCompleteFile(buffer), true);
+    TEST_EQUAL(std::filesystem::file_size(m_filePath), 2 * buffer.blockSize);
 
     // cleanup
     TEST_EQUAL(binaryFile.closeFile(), true);

--- a/tests/unit_tests/libKitsunemimiCommon/files/binary_file_without_directIO_test.cpp
+++ b/tests/unit_tests/libKitsunemimiCommon/files/binary_file_without_directIO_test.cpp
@@ -217,10 +217,8 @@ BinaryFile_withoutDirectIO_Test::writeCompleteFile_test()
     testStruct.c = 1234;
     addObject_DataBuffer(buffer, &testStruct);
 
-    // test with buffer-size unequal a multiple of the block-size
-    buffer.usedBufferSize = 2 * buffer.blockSize + 1;
-
     TEST_EQUAL(binaryFile.writeCompleteFile(buffer), true);
+    TEST_EQUAL(std::filesystem::file_size(m_filePath), 2 * sizeof(TestStruct));
 
     // cleanup
     TEST_EQUAL(binaryFile.closeFile(), true);


### PR DESCRIPTION
## Description

fix writeCompleteFile-function to writhe the correct size

## Related Issues

- #182 

## How it was tested?

- updates unit-test-which now also checks the size of the file, which was written with `writeCompleteFile`