### PR TITLE
Allow other types beside strings in table for input and output

### DIFF
--- a/include/libKitsunemimiCommon/common_items/table_item.h
+++ b/include/libKitsunemimiCommon/common_items/table_item.h
@@ -46,6 +46,7 @@ public:
     bool deleteColumn(const std::string &internalName);
 
     // row
+    bool addRow(DataArray* rowContent, const bool copy = false);
     bool addRow(const std::vector<std::string> rowContent);
     bool deleteRow(const uint64_t y);
 

--- a/src/common_items/table_item.cpp
+++ b/src/common_items/table_item.cpp
@@ -210,15 +210,46 @@ TableItem::deleteColumn(const std::string &internalName)
 }
 
 /**
+ * @brief TableItem::addRow
+ *
+ * @param rowContent new table-row
+ * @param copy true to make a copy of the new row-content (DEFAULT: false)
+ *
+ * @return false, if the new row has not the correct length to fit into the table, else true
+ */
+bool
+TableItem::addRow(DataArray* rowContent, const bool copy)
+{
+    // check if the new row has the correct length
+    if(rowContent->size() != getNumberOfColums()) {
+        return false;
+    }
+
+    // add new row
+    if(copy) {
+        m_body->append(rowContent->copy());
+    } else {
+        m_body->append(rowContent);
+    }
+
+    return true;
+}
+
+/**
  * @brief add a new row to the table
  *
  * @param rowContent vector of string for the content of the new row
  *
- * @return should return true everytime
+ * @return false, if the new row has not the correct length to fit into the table, else true
  */
 bool
 TableItem::addRow(const std::vector<std::string> rowContent)
 {
+    // check if the new row has the correct length
+    if(rowContent.size() != getNumberOfColums()) {
+        return false;
+    }
+
     DataArray* obj = new DataArray();
 
     // check and cut size
@@ -317,7 +348,7 @@ TableItem::getCell(const uint32_t column,
     }
 
     // return value-content as string
-    return value->getString();
+    return value->toString();
 }
 
 /**
@@ -647,7 +678,7 @@ TableItem::convertBodyForOutput(TableBodyAll &convertedBody,
             // get cell content or use empty string, if cell not exist
             DataItem* value = m_body->get(y)->get(x);
             if(value != nullptr) {
-                cellContent = value->toValue()->getString();
+                cellContent = value->toValue()->toString();
             }
 
             // split cell content

--- a/tests/unit_tests/libKitsunemimiCommon/common_items/table_item_test.cpp
+++ b/tests/unit_tests/libKitsunemimiCommon/common_items/table_item_test.cpp
@@ -171,7 +171,14 @@ TableItem_test::addRow_Test()
     testItem.addColumn("poipoipoi");
 
     TEST_EQUAL(testItem.addRow(std::vector<std::string>{"this is a test", "k"}), true);
-    TEST_EQUAL(testItem.addRow(std::vector<std::string>{"asdf", "qwert"}), true);
+    TEST_EQUAL(testItem.addRow(std::vector<std::string>{"asdf"}), false);
+
+    DataArray* newRow = new DataArray();
+    newRow->append(new DataValue("asdf"));
+    TEST_EQUAL(testItem.addRow(newRow), false);
+    newRow->append(new DataValue(42));
+    TEST_EQUAL(testItem.addRow(newRow), true);
+
 
     const std::string compare =
             "+----------------+-----------+\n"
@@ -179,7 +186,7 @@ TableItem_test::addRow_Test()
             "+================+===========+\n"
             "| this is a test | k         |\n"
             "+----------------+-----------+\n"
-            "| asdf           | qwert     |\n"
+            "| asdf           | 42        |\n"
             "+----------------+-----------+\n";
 
     TEST_EQUAL(testItem.toString(), compare);


### PR DESCRIPTION
## Description

Allow other types beside strings in table for input and output

## Related Issues

- #189 

## How it was tested?

- update unit-tests
