### PR TITLE
updates for tagging 0.25.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.25.0] - 2021-12-30
+
+## Added
+- support other types in table beside string-objects
+- support list of core-ids instead of only a single code-id for thread-binding
+
+
 ## [0.24.0] - 2021-11-26
 
 ## Added

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT       -= qt core gui
 TARGET = KitsunemimiCommon
 TEMPLATE = lib
 CONFIG += c++17
-VERSION = 0.24.0
+VERSION = 0.25.0
 
 INCLUDEPATH += $$PWD \
             ../include


### PR DESCRIPTION
## Description

- updates for tagging 0.25.0

## Related Issues

- #193 

## How it was tested?

- ci-pipeline