### PR TITLE
updates for tagging 0.26.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.26.0] - 2022-06-26
+
+### Changed
+- Header of item-buffer was restructured to be stored in the buffer itself too
+
+### Added
+- States of statemachine can now be connected to events, which are triggered, when entering the state
+- Event-Queue to be also able to execute the Events of states by a separate thread
+- item-buffer can now be completely backuped and restored
+
+### Fixed
+- added missing include in state-class
+
+
 ## [0.25.3] - 2022-02-13
 
 ### Added

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT       -= qt core gui
 TARGET = KitsunemimiCommon
 TEMPLATE = lib
 CONFIG += c++17
-VERSION = 0.25.3
+VERSION = 0.26.0
 
 INCLUDEPATH += $$PWD \
             ../include


### PR DESCRIPTION
## Description

updates for tagging 0.26.0

## Related Issues

- #218 

## How it was tested?

- unit-tests and while using in other projects
- event-trigger with separate event-queue-thread not fully tested at the moment
