### PR TITLE
updates for tagging 0.26.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.26.1] - 2022-07-02
+
+### Fixed
+- removed broken precheck of thread-binding-functions
+
+
 ## [0.26.0] - 2022-06-26
 
 ### Changed

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,7 +3,7 @@ QT       -= qt core gui
 TARGET = KitsunemimiCommon
 TEMPLATE = lib
 CONFIG += c++17
-VERSION = 0.26.0
+VERSION = 0.26.1
 
 INCLUDEPATH += $$PWD \
             ../include


### PR DESCRIPTION
## Description

updates for tagging 0.26.1

## Related Issues

- #222 

## How it was tested?

- ci-pipeline
- manually testing of changes in other projects