### PR TITLE
Fix: fix memory-leak when deleteing table-cell

### DIFF
--- a/src/items/data_items.cpp
+++ b/src/items/data_items.cpp
@@ -634,7 +634,7 @@ void
 DataValue::setValue(const char* value)
 {
     if(m_valueType == STRING_TYPE) {
-        delete content.stringValue;
+        delete[] content.stringValue;
     }
 
     m_type = VALUE_TYPE;
@@ -662,7 +662,7 @@ void
 DataValue::setValue(const std::string &value)
 {
     if(m_valueType == STRING_TYPE) {
-        delete content.stringValue;
+        delete[] content.stringValue;
     }
 
     m_type = VALUE_TYPE;
@@ -680,7 +680,7 @@ void
 DataValue::setValue(const int &value)
 {
     if(m_valueType == STRING_TYPE) {
-        delete content.stringValue;
+        delete[] content.stringValue;
     }
 
     m_type = VALUE_TYPE;
@@ -728,7 +728,7 @@ void
 DataValue::setValue(const double &value)
 {
     if(m_valueType == STRING_TYPE) {
-        delete content.stringValue;
+        delete[] content.stringValue;
     }
 
     m_type = VALUE_TYPE;

--- a/src/items/table_item.cpp
+++ b/src/items/table_item.cpp
@@ -250,16 +250,9 @@ TableItem::addRow(const std::vector<std::string> rowContent)
         return false;
     }
 
-    DataArray* obj = new DataArray();
-
-    // check and cut size
-    uint64_t size = rowContent.size();
-    if(m_header->size() < size) {
-        size = m_header->size();
-    }
-
     // add new row content to the table
-    for(uint64_t x = 0; x < size; x++) {
+    DataArray* obj = new DataArray();
+    for(uint64_t x = 0; x < rowContent.size(); x++) {
         obj->append(new DataValue(rowContent.at(x)));
     }
 
@@ -371,7 +364,9 @@ TableItem::deleteCell(const uint32_t column,
     }
 
     // remove value if possible
+    delete m_body->get(row)->toArray()->array[column];
     m_body->get(row)->toArray()->array[column] = nullptr;
+
     return true;
 }
 
@@ -464,8 +459,9 @@ TableItem::stealContent()
 DataArray*
 TableItem::getRow(const uint32_t row, const bool copy) const
 {
+    // check if out of range
     if(row >= m_body->size()) {
-        return new DataArray();
+        return nullptr;
     }
 
     if(copy) {

--- a/tests/memory_leak_tests/libKitsunemimiCommon/items/table_item_test.cpp
+++ b/tests/memory_leak_tests/libKitsunemimiCommon/items/table_item_test.cpp
@@ -76,6 +76,7 @@ TableItem_test::add_delete_row_test()
     REINIT_TEST();
 
     testItem.addRow(std::vector<std::string>{"this is a test", "k"});
+    testItem.deleteCell(0, 0);
     testItem.deleteRow(0);
 
     CHECK_MEMORY();

--- a/tests/unit_tests/libKitsunemimiCommon/items/data_items_DataValue_test.cpp
+++ b/tests/unit_tests/libKitsunemimiCommon/items/data_items_DataValue_test.cpp
@@ -171,6 +171,7 @@ DataItems_DataValue_Test::copy_test()
     TEST_EQUAL(boolValue.content.boolValue, boolValueCopy->content.boolValue);
 
     // cleanup
+    delete boolValueCopy;
     delete defaultValueCopy;
     delete stringValueCopy;
     delete intValueCopy;

--- a/tests/unit_tests/libKitsunemimiCommon/items/table_item_test.cpp
+++ b/tests/unit_tests/libKitsunemimiCommon/items/table_item_test.cpp
@@ -101,6 +101,8 @@ TableItem_test::stealContent_test()
 
     TEST_EQUAL(testItem.getNumberOfRows(), 0);
     TEST_EQUAL(testItem.getNumberOfColums(), 0);
+
+    delete data;
 }
 
 /**
@@ -207,8 +209,7 @@ TableItem_test::getRow_Test()
 
     result = testItem.getRow(42, false);
     const bool isNullptr = result == nullptr;
-    TEST_EQUAL(isNullptr, false);
-    TEST_EQUAL(result->size(), 0);
+    TEST_EQUAL(isNullptr, true);
 
     result = testItem.getRow(1, false);
     const std::string compare = "[\"asdf\",\"qwert\"]";
@@ -333,6 +334,8 @@ TableItem_test::getInnerHeader_test()
     TEST_EQUAL(innerHader->size(), 2);
     TEST_EQUAL(innerHader->get(0)->toValue()->getString(), "asdf");
     TEST_EQUAL(innerHader->get(1)->toValue()->getString(), "poipoipoi");
+
+    delete innerHader;
 }
 
 /**
@@ -425,7 +428,6 @@ TableItem_test::getTestTableItem()
 
     testItem.addRow(std::vector<std::string>{"this is a test", "k"});
     testItem.addRow(std::vector<std::string>{"asdf", "qwert"});
-
     return testItem;
 }
 


### PR DESCRIPTION
## Description

Fix: fix memory-leak when deleteing table-cell

## Related Issues

- #236 

## How it was tested?

- manually with valgrind
- updated memory-leak-test
